### PR TITLE
Change marker-output and sourceFrame-String

### DIFF
--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -46,10 +46,10 @@ task_context "Task" do
     #Output Ports
     output_port("output_image", ro_ptr("/base/samples/frame/Frame"))
         .doc 'Image that shows the detected markers'
-#    output_port("marker_poses", "std/vector<base::samples::RigidBodyState>")
-#        .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
-    output_port("marker_poses", "base::samples::RigidBodyState")
+    output_port("marker_poses", "std/vector<base::samples::RigidBodyState>")
         .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
+#    output_port("marker_poses", "base::samples::RigidBodyState")
+#        .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
     output_port("marker2cam", "base::samples::RigidBodyState")
     output_port("detected_corners", "std/vector<base::Vector2d>")
      	.doc 'Writes the camera calibration to be acessible to other components' 	

--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -50,6 +50,7 @@ task_context "Task" do
 #        .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
     output_port("marker_poses", "base::samples::RigidBodyState")
         .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
+    output_port("marker2cam", "base::samples::RigidBodyState")
     output_port("detected_corners", "std/vector<base::Vector2d>")
      	.doc 'Writes the camera calibration to be acessible to other components' 	
      	

--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -35,8 +35,6 @@ task_context "Task" do
         .doc 'Value of the marker in meters'
     property("draw_image", "bool", true)
         .doc 'Write the image on the output_port'
-    property("source_frame","string","camera_frame")
-        .doc 'Name of the source frame'
      
 
     #Input Ports
@@ -48,9 +46,8 @@ task_context "Task" do
         .doc 'Image that shows the detected markers'
     output_port("marker_poses", "std/vector<base::samples::RigidBodyState>")
         .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
-#    output_port("marker_poses", "base::samples::RigidBodyState")
-#        .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
-    output_port("marker2cam", "base::samples::RigidBodyState")
+    output_port("single_marker_pose", "base::samples::RigidBodyState")
+	.doc 'It contains a single calculated marker pose in respect to camera of a deteted visable marker'
     output_port("detected_corners", "std/vector<base::Vector2d>")
      	.doc 'Writes the camera calibration to be acessible to other components' 	
      	

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -234,7 +234,10 @@ void Task::updateHook()
 			//write the markers in the output port
 			if (rbs_vector.size() != 0)
 			{
+				base::samples::RigidBodyState rbs_marker2cam = rbs_vector[0];
+				rbs_marker2cam.setTransform(  rbs_marker2cam.getTransform().inverse() );
 				_marker_poses.write(rbs_vector[0]);
+				_marker2cam.write( rbs_marker2cam );
 				rbs_vector.clear();
 			}
 		}

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -238,13 +238,13 @@ void Task::updateHook()
 				rbs_marker2cam.setTransform(  rbs_marker2cam.getTransform().inverse() );
 				std::vector<base::samples::RigidBodyState> marker_poses;
 				for(unsigned i = 0; i < rbs_vector.size(); i++)
-                {
-                    base::samples::RigidBodyState marker2cam = rbs_vector[i];
-                    marker2cam.setTransform(  rbs_vector[i].getTransform().inverse() );
-                    marker_poses.push_back(marker2cam);
-                }
+				{
+				    base::samples::RigidBodyState marker2cam = rbs_vector[i];
+				    marker2cam.setTransform(  rbs_vector[i].getTransform().inverse() );
+				    marker_poses.push_back(marker2cam);
+				}
 				_marker_poses.write(marker_poses);
-				_marker2cam.write( rbs_marker2cam );
+				_single_marker_pose.write( rbs_marker2cam );
 				rbs_vector.clear();
 			}
 		}

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -239,8 +239,8 @@ void Task::updateHook()
 				std::vector<base::samples::RigidBodyState> marker_poses;
 				for(unsigned i = 0; i < rbs_vector.size(); i++)
                 {
-                    base::samples::RigidBodyState marker2cam = rbs_vector[0];
-                    marker2cam.setTransform(  rbs_vector[0].getTransform().inverse() );
+                    base::samples::RigidBodyState marker2cam = rbs_vector[i];
+                    marker2cam.setTransform(  rbs_vector[i].getTransform().inverse() );
                     marker_poses.push_back(marker2cam);
                 }
 				_marker_poses.write(marker_poses);
@@ -497,7 +497,7 @@ void Task::EulerToQuaternion(base::Vector3d &eulerang, base::Orientation &quater
 
 std::string Task::getMarkerFrameName(int i){
     std::stringstream ss;
-    ss << "aruco_id_" << i << "_frame";
+    ss << "apriltag_id_" << i << "_frame";
     std::string marker_frame_name = ss.str();
     
     return marker_frame_name;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -161,7 +161,7 @@ void Task::updateHook()
 				//estimate pose and push_back to rbs_vector
 				base::samples::RigidBodyState rbs;
 				getRbs(rbs, _marker_size.get(), det->p, camera_k, cv::Mat());
-				rbs.sourceFrame = _source_frame.get();
+				rbs.sourceFrame = getMarkerFrameName( det->id);
 				rbs.time = current_frame_ptr->time;
 				rbs_vector.push_back(rbs);
 
@@ -368,14 +368,14 @@ void Task::getRbs(base::samples::RigidBodyState &rbs, float markerSizeMeters, do
 void Task::draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color, int lineWidth)const
 {
 
-    cv::line( in,cv::Point(p[0][0], p[0][1]),cv::Point(p[1][0], p[1][1]),color,lineWidth,cv::LINE_AA);
-    cv::line( in,cv::Point(p[1][0], p[1][1]),cv::Point(p[2][0], p[2][1]),color,lineWidth,cv::LINE_AA);
-    cv::line( in,cv::Point(p[2][0], p[2][1]),cv::Point(p[3][0], p[3][1]),color,lineWidth,cv::LINE_AA);
-    cv::line( in,cv::Point(p[3][0], p[3][1]),cv::Point(p[0][0], p[0][1]),color,lineWidth,cv::LINE_AA);
+    cv::line( in,cv::Point(p[0][0], p[0][1]),cv::Point(p[1][0], p[1][1]),color,lineWidth,8);
+    cv::line( in,cv::Point(p[1][0], p[1][1]),cv::Point(p[2][0], p[2][1]),color,lineWidth,8);
+    cv::line( in,cv::Point(p[2][0], p[2][1]),cv::Point(p[3][0], p[3][1]),color,lineWidth,8);
+    cv::line( in,cv::Point(p[3][0], p[3][1]),cv::Point(p[0][0], p[0][1]),color,lineWidth,8);
 
-    cv::rectangle( in,cv::Point(p[0][0], p[0][1]) - cv::Point(2,2),cv::Point(p[0][0], p[0][1])+cv::Point(2,2),cv::Scalar(0,0,255,255),lineWidth,cv::LINE_AA);
-    cv::rectangle( in,cv::Point(p[1][0], p[1][1]) - cv::Point(2,2),cv::Point(p[1][0], p[1][1])+cv::Point(2,2),cv::Scalar(0,255,0,255),lineWidth,cv::LINE_AA);
-    cv::rectangle( in,cv::Point(p[2][0], p[2][1]) - cv::Point(2,2),cv::Point(p[2][0], p[2][1])+cv::Point(2,2),cv::Scalar(255,0,0,255),lineWidth,cv::LINE_AA);
+    cv::rectangle( in,cv::Point(p[0][0], p[0][1]) - cv::Point(2,2),cv::Point(p[0][0], p[0][1])+cv::Point(2,2),cv::Scalar(0,0,255,255),lineWidth,8);
+    cv::rectangle( in,cv::Point(p[1][0], p[1][1]) - cv::Point(2,2),cv::Point(p[1][0], p[1][1])+cv::Point(2,2),cv::Scalar(0,255,0,255),lineWidth,8);
+    cv::rectangle( in,cv::Point(p[2][0], p[2][1]) - cv::Point(2,2),cv::Point(p[2][0], p[2][1])+cv::Point(2,2),cv::Scalar(255,0,0,255),lineWidth,8);
 
         char cad[100];
         sprintf(cad,"id=%d",id);
@@ -428,13 +428,13 @@ void Task::draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Ma
 
     //draw lines of different colours
     for (int i=0;i<4;i++)
-        cv::line(Image,imagePoints[i],imagePoints[(i+1)%4],cv::Scalar(0,0,255,255),1,cv::LINE_AA);
+        cv::line(Image,imagePoints[i],imagePoints[(i+1)%4],cv::Scalar(0,0,255,255),1,8);
 
     for (int i=0;i<4;i++)
-        cv::line(Image,imagePoints[i+4],imagePoints[4+(i+1)%4],cv::Scalar(0,0,255,255),1,cv::LINE_AA);
+        cv::line(Image,imagePoints[i+4],imagePoints[4+(i+1)%4],cv::Scalar(0,0,255,255),1,8);
 
     for (int i=0;i<4;i++)
-        cv::line(Image,imagePoints[i],imagePoints[i+4],cv::Scalar(0,0,255,255),1,cv::LINE_AA);
+        cv::line(Image,imagePoints[i],imagePoints[i+4],cv::Scalar(0,0,255,255),1,8);
 
 }
 
@@ -459,9 +459,9 @@ void Task::draw3dAxis(cv::Mat &Image, float marker_size, cv::Mat camera_matrix, 
 
     cv::projectPoints( objectPoints, rvec, tvec, camera_matrix, dist_matrix, imagePoints);
     //draw lines of different colours
-    cv::line(Image,imagePoints[0],imagePoints[1],cv::Scalar(0,0,255,255),1,cv::LINE_AA);
-    cv::line(Image,imagePoints[0],imagePoints[2],cv::Scalar(0,255,0,255),1,cv::LINE_AA);
-    cv::line(Image,imagePoints[0],imagePoints[3],cv::Scalar(255,0,0,255),1,cv::LINE_AA);
+    cv::line(Image,imagePoints[0],imagePoints[1],cv::Scalar(0,0,255,255),1,8);
+    cv::line(Image,imagePoints[0],imagePoints[2],cv::Scalar(0,255,0,255),1,8);
+    cv::line(Image,imagePoints[0],imagePoints[3],cv::Scalar(255,0,0,255),1,8);
     cv::putText(Image,"x", imagePoints[1],cv::FONT_HERSHEY_SIMPLEX, 0.6, cv::Scalar(0,0,255,255),2);
     cv::putText(Image,"y", imagePoints[2],cv::FONT_HERSHEY_SIMPLEX, 0.6, cv::Scalar(0,255,0,255),2);
     cv::putText(Image,"z", imagePoints[3],cv::FONT_HERSHEY_SIMPLEX, 0.6, cv::Scalar(255,0,0,255),2);
@@ -480,5 +480,13 @@ void Task::EulerToQuaternion(base::Vector3d &eulerang, base::Orientation &quater
 	quaternion.x() = ( sin(eulerang(0)/2)*cos(eulerang(1)/2)*cos(eulerang(2)/2) ) - ( cos(eulerang(0)/2)*sin(eulerang(1)/2)*sin(eulerang(2)/2) );
 	quaternion.y() = ( cos(eulerang(0)/2)*sin(eulerang(1)/2)*cos(eulerang(2)/2) ) + ( sin(eulerang(0)/2)*cos(eulerang(1)/2)*sin(eulerang(2)/2) );
 	quaternion.z() = ( cos(eulerang(0)/2)*cos(eulerang(1)/2)*sin(eulerang(2)/2) ) - ( sin(eulerang(0)/2)*sin(eulerang(1)/2)*cos(eulerang(2)/2) );
+}
+
+std::string Task::getMarkerFrameName(int i){
+    std::stringstream ss;
+    ss << "aruco_id_" << i << "_frame";
+    std::string marker_frame_name = ss.str();
+    
+    return marker_frame_name;
 }
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -236,7 +236,14 @@ void Task::updateHook()
 			{
 				base::samples::RigidBodyState rbs_marker2cam = rbs_vector[0];
 				rbs_marker2cam.setTransform(  rbs_marker2cam.getTransform().inverse() );
-				_marker_poses.write(rbs_vector[0]);
+				std::vector<base::samples::RigidBodyState> marker_poses;
+				for(unsigned i = 0; i < rbs_vector.size(); i++)
+                {
+                    base::samples::RigidBodyState marker2cam = rbs_vector[0];
+                    marker2cam.setTransform(  rbs_vector[0].getTransform().inverse() );
+                    marker_poses.push_back(marker2cam);
+                }
+				_marker_poses.write(marker_poses);
 				_marker2cam.write( rbs_marker2cam );
 				rbs_vector.clear();
 			}

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -59,6 +59,7 @@ namespace apriltags {
     void draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Mat distCoeff);
     void EulerToQuaternion(base::Vector3d &eulerang, base::Orientation &quaternion);
     double tic();
+    std::string getMarkerFrameName(int i);
 
     public:
         /** TaskContext constructor for Task


### PR DESCRIPTION
Hi,

I made some changes, to make the interface of this detection-task more similar to the aruco-detector-task.
1. The output is now a single RigidbodyState and a vector of all detected RigidBodyStates. In the old version, the output was simply the Pose of the first detected Marker, even there were multiple marker in the image.
2. The output-pose of the marker is now the pose of the marker with respect to the camera. In the old version, the output was inversed and was the camera-pose with respect to the marker (which violates the port-documentation in the orogen-file)
3. I added the marker-ID to the sourceFrame-String of the RigidBodyState. The string is now "apriltag_id_X_frame", where X is the ID of the marker. This is similar to the output of the aruco-Task. In the old version, there was only a constant string with no informations about the marker-ID.
