### PR TITLE
Add optional mapping from marker-id to marker-size

### DIFF
--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -33,6 +33,9 @@ task_context "Task" do
         .doc 'Calibration parameters for the camera, which are used to undistort and are added as attributes to the frames'
     property("marker_size", "double", -1)
         .doc 'Value of the marker in meters'
+    property("apriltag_id_to_size", "/std/vector<apriltags/ApriltagIDToSize>").
+	doc("Mapping from Apriltag-ID to marker size. This could be used, if there are multiple marker with different sizes to be detected").
+	doc("This property is OPTIONAL. If not set, the marker_size-property is used")
     property("draw_image", "bool", true)
         .doc 'Write the image on the output_port'
      

--- a/apriltagsTypes.hpp
+++ b/apriltagsTypes.hpp
@@ -41,6 +41,12 @@ namespace apriltags {
         bool refine_decode; // Spend more time trying to decode tags
         bool refine_pose; // Spend more time trying to precisely localize tags
 	};
+	
+   struct ApriltagIDToSize
+   {
+      int id;
+      double marker_size; //in meters  
+   };
 
 }
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -82,7 +82,8 @@ bool Task::configureHook()
 	apriltag_id_to_size_.clear();
 	
 	//Initialize the id2size mapping
-	for(std::vector<ApriltagIDToSize>::iterator it = apriltag_size_id.begin(); it != apriltag_size_id.end(); it++){
+	for(std::vector<ApriltagIDToSize>::iterator it = apriltag_size_id.begin(); it != apriltag_size_id.end(); it++)
+	{
 	
 	  apriltag_id_to_size_[ it->id] = it->marker_size;
 	  
@@ -179,7 +180,8 @@ void Task::updateHook()
 				{
 				  size = apriltag_id_to_size_[ det->id];
 				}
-				else{
+				else
+				{
 				  size = _marker_size.get();
 				}
 
@@ -476,7 +478,8 @@ double Task::tic()
     return ((double)t.tv_sec + ((double)t.tv_usec)/1000000.);
 }
 
-std::string Task::getMarkerFrameName(int i){
+std::string Task::getMarkerFrameName(int i)
+{
     std::stringstream ss;
     ss << "apriltag_id_" << i << "_frame";
     std::string marker_frame_name = ss.str();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -58,6 +58,8 @@ namespace apriltags {
 
     RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> out_frame_ptr;
 
+    std::map<int, double> apriltag_id_to_size_; //Mapping from ID to size
+    
     void getRbs(base::samples::RigidBodyState &rbs, float markerSizeMeters, double points[][2], cv::Mat  camMatrix,cv::Mat distCoeff)throw(cv::Exception);
     void draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color, int lineWidth)const;
     void draw3dAxis(cv::Mat &Image, float marker_size, cv::Mat camera_matrix, cv::Mat dist_matrix);


### PR DESCRIPTION
Hi,

I added an optional property, where you can define a mapping from marker-id to marker-size.
This is helpfull in situations, where you have multiple apriltags with different, known sizes.
This property is optional, if you do not specify it, the marker_size-property is used for all detected apriltags.
