### PR TITLE
fix property name for camera frame

### DIFF
--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -44,7 +44,7 @@ task_context "Task" do
         .doc 'Write the image on the output_port'
     property("scale_image", "double", 1.0)
         .doc 'applies this scaling to the image and calibration parameters'
-    property("camera_frame_name", "/std/string")
+    property("camera_frame", "/std/string")
         .doc 'Frame name of the camera'
      
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -189,11 +189,11 @@ void Task::updateHook()
 			double t2=tic();
 			double t_detect = t2-t1; t1=t2;
 
-            if (zarray_size(detections) != 0 & state() != MARKER_DETECTED)
+            if (zarray_size(detections) != 0 && state() != MARKER_DETECTED)
             {
                 state(MARKER_DETECTED);
             }
-            else if(zarray_size(detections) == 0 & state() != NO_MARKER_DETECTED)
+            else if(zarray_size(detections) == 0 && state() != NO_MARKER_DETECTED)
             {
                 state(NO_MARKER_DETECTED);
             }
@@ -224,11 +224,11 @@ void Task::updateHook()
                     if (_marker2camera)
                     {
                         rbs.sourceFrame = getMarkerFrameName(det->id);
-                        rbs.targetFrame = _camera_frame_name.value();
+                        rbs.targetFrame = _camera_frame.value();
                     }
                     else
                     {
-                        rbs.sourceFrame = _camera_frame_name.value();
+                        rbs.sourceFrame = _camera_frame.value();
                         rbs.targetFrame = getMarkerFrameName(det->id);
                     }
                     rbs.time = current_frame_ptr->time;


### PR DESCRIPTION
This renames the camera frame name property to match the transformer
convention. Required for the Syskit integration.
