### PR TITLE
Create new properties

### DIFF
--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -29,6 +29,8 @@ task_context "Task" do
               @param bool refine_edges // Spend more time trying to align edges of tags
               @param bool refine_decode // Spend more time trying to decode tags
               @param bool refine_pose // Spend more time trying to precisely localize tags'
+    property("pose_calculation", "bool", true)
+        .doc 'If false, the marker is detected but the pose is not calculated'
     property("camera_calibration", "frame_helper/CameraCalibration")
         .doc 'Calibration parameters for the camera, which are used to undistort and are added as attributes to the frames'
     property("marker_size", "double", -1)

--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -42,7 +42,7 @@ task_context "Task" do
         .doc 'Write the image on the output_port'
     property("scale_image", "double", 1.0)
         .doc 'applies this scaling to the image and calibration parameters'
-    property("camera_frame_name", "/std/string")
+    property("camera_frame", "/std/string")
         .doc 'Frame name of the camera'
      
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -25,169 +25,171 @@ Task::~Task()
 
 bool Task::configureHook()
 {
-	if (! TaskBase::configureHook())
-		return false;
+    if (! TaskBase::configureHook())
+        return false;
 
-	// setting camera matrix and distortion matrix
-	frame_helper::CameraCalibration cal = _camera_calibration.get();
+    // setting camera matrix and distortion matrix
+    frame_helper::CameraCalibration cal = _camera_calibration.get();
 
-        // apply scaling to calibration parameters
-        scaling = 1.0;
-        if(_scale_image.value() > 0.0 && _scale_image.value() != 1.0)
-            scaling = _scale_image.value();
-        if(scaling != 1.0)
-        {
-            cal.fx = scaling * cal.fx;
-            cal.fy = scaling * cal.fy;
-            cal.cx = scaling * cal.cx;
-            cal.cy = scaling * cal.cy;
-            cal.height = scaling * cal.height;
-            cal.width = scaling * cal.width;
-        }
+    // apply scaling to calibration parameters
+    scaling = 1.0;
+    if(_scale_image.value() > 0.0 && _scale_image.value() != 1.0)
+        scaling = _scale_image.value();
+    if(scaling != 1.0)
+    {
+        cal.fx = scaling * cal.fx;
+        cal.fy = scaling * cal.fy;
+        cal.cx = scaling * cal.cx;
+        cal.cy = scaling * cal.cy;
+        cal.height = scaling * cal.height;
+        cal.width = scaling * cal.width;
+    }
 
-	camera_k = (cv::Mat_<double>(3,3) << cal.fx, 0, cal.cx,
-                                            0, cal.fy, cal.cy,
-                                            0, 0, 1);
-	camera_dist = (cv::Mat_<double>(1,4) << cal.d0, cal.d1, cal.d2, cal.d3);
+    camera_k = (cv::Mat_<double>(3,3) << cal.fx, 0, cal.cx,
+            0, cal.fy, cal.cy,
+            0, 0, 1);
+    camera_dist = (cv::Mat_<double>(1,4) << cal.d0, cal.d1, cal.d2, cal.d3);
 
-	// setting immutable parameters
-	conf = _conf_param.get();
+    // setting immutable parameters
+    conf = _conf_param.get();
 
-	rvec.create(3,1,CV_64FC1);
-	tvec.create(3,1,CV_64FC1);
+    rvec.create(3,1,CV_64FC1);
+    tvec.create(3,1,CV_64FC1);
 
-	// Initialize the undistortion maps:
-	cv::initUndistortRectifyMap(camera_k, camera_dist, cv::Mat(), camera_k, cv::Size(cal.width, cal.height), CV_16SC2, undist_map1, undist_map2);
+    // Initialize the undistortion maps:
+    cv::initUndistortRectifyMap(camera_k, camera_dist, cv::Mat(), camera_k, cv::Size(cal.width, cal.height), CV_16SC2, undist_map1, undist_map2);
 
-	// Initialize April-Detector library:
-	//set the apriltag family
-	tf = NULL;
-	switch (conf.family)
-	{
-	case TAG25H7:
-		tf = tag25h7_create();
-		break;
-	case TAG25H9:
-		tf = tag25h9_create();
-		break;
-	case TAG36H10:
-		tf = tag36h10_create();
-		break;
-	case TAG36H11:
-		tf = tag36h11_create();
-		break;
-	case TAG36ARTOOLKIT:
-		tf = tag36artoolkit_create();
-		break;
-	default:
-		throw std::runtime_error("The desired apriltag family code is not implemented");
-		break;
-	}
+    // Initialize April-Detector library:
+    //set the apriltag family
+    tf = NULL;
+    switch (conf.family)
+    {
+        case TAG25H7:
+            tf = tag25h7_create();
+            break;
+        case TAG25H9:
+            tf = tag25h9_create();
+            break;
+        case TAG36H10:
+            tf = tag36h10_create();
+            break;
+        case TAG36H11:
+            tf = tag36h11_create();
+            break;
+        case TAG36ARTOOLKIT:
+            tf = tag36artoolkit_create();
+            break;
+        default:
+            throw std::runtime_error("The desired apriltag family code is not implemented");
+            break;
+    }
 
-	// create a apriltag detector and add the current family
-	td = apriltag_detector_create();
-	apriltag_detector_add_family(td, tf);
-	td->quad_decimate = conf.decimate;
-	td->quad_sigma = conf.blur;
-	td->nthreads = conf.threads;
-	td->debug = conf.debug;
-	td->refine_edges = conf.refine_edges;
-	td->refine_decode = conf.refine_decode;
-	td->refine_pose = conf.refine_pose;
+    // create a apriltag detector and add the current family
+    td = apriltag_detector_create();
+    apriltag_detector_add_family(td, tf);
+    td->quad_decimate = conf.decimate;
+    td->quad_sigma = conf.blur;
+    td->nthreads = conf.threads;
+    td->debug = conf.debug;
+    td->refine_edges = conf.refine_edges;
+    td->refine_decode = conf.refine_decode;
+    td->refine_pose = conf.refine_pose;
 
-	std::vector<ApriltagIDToSize> apriltag_size_id = _apriltag_id_to_size.get();
-	apriltag_id_to_size_.clear();
-	
-	//Initialize the id2size mapping
-	for(std::vector<ApriltagIDToSize>::iterator it = apriltag_size_id.begin(); it != apriltag_size_id.end(); it++)
-	{
-	
-	  apriltag_id_to_size_[ it->id] = it->marker_size;
-	  
-	}
-	
-	
-	return true;
+    std::vector<ApriltagIDToSize> apriltag_size_id = _apriltag_id_to_size.get();
+    apriltag_id_to_size_.clear();
+
+    //Initialize the id2size mapping
+    for(std::vector<ApriltagIDToSize>::iterator it = apriltag_size_id.begin(); it != apriltag_size_id.end(); it++)
+    {
+
+        apriltag_id_to_size_[ it->id] = it->marker_size;
+
+    }
+
+
+    return true;
 }
+
 bool Task::startHook()
 {
 	if (! TaskBase::startHook())
 		return false;
 	return true;
 }
+
 void Task::updateHook()
 {
-	TaskBase::updateHook();
+    TaskBase::updateHook();
 
-	RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> current_frame_ptr;
-	frame_helper::FrameHelper frameHelper;
-	base::samples::frame::Frame current_frame;
-	//main loop for detection in each input frame
-	for(int count=0; _image.read(current_frame_ptr) == RTT::NewData; ++count)
-	{
-		double t0 = tic();
-		//convert base::samples::frame::Frame to grayscale cv::Mat
-		cv::Mat image;
-		base::samples::frame::Frame temp_frame;
+    RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> current_frame_ptr;
+    frame_helper::FrameHelper frameHelper;
+    base::samples::frame::Frame current_frame;
+    //main loop for detection in each input frame
+    for(int count=0; _image.read(current_frame_ptr) == RTT::NewData; ++count)
+    {
+        double t0 = tic();
+        //convert base::samples::frame::Frame to grayscale cv::Mat
+        cv::Mat image;
+        base::samples::frame::Frame temp_frame;
 
-		// convert arbitrary input to BGR frame.
-		// TODO for better performance this could be directly converted to MODE_GRAYSCALE, especially if out_frame is not connected
-		current_frame.init( current_frame_ptr->size.width, current_frame_ptr->size.height, 8, base::samples::frame::MODE_BGR );
-		frameHelper.convert( *current_frame_ptr, current_frame, 0, 0, frame_helper::INTER_LINEAR, false);
-		image = frame_helper::FrameHelper::convertToCvMat(current_frame);
+        // convert arbitrary input to BGR frame.
+        // TODO for better performance this could be directly converted to MODE_GRAYSCALE, especially if out_frame is not connected
+        current_frame.init( current_frame_ptr->size.width, current_frame_ptr->size.height, 8, base::samples::frame::MODE_BGR );
+        frameHelper.convert( *current_frame_ptr, current_frame, 0, 0, frame_helper::INTER_LINEAR, false);
+        image = frame_helper::FrameHelper::convertToCvMat(current_frame);
 
-                // scale image size
-                if(scaling != 1.0)
-                {
-                    cv::Mat image_scaled;
-                    cv::resize(image, image_scaled, cv::Size(), scaling, scaling);
-                    image = image_scaled;
-                }
+        // scale image size
+        if(scaling != 1.0)
+        {
+            cv::Mat image_scaled;
+            cv::resize(image, image_scaled, cv::Size(), scaling, scaling);
+            image = image_scaled;
+        }
 
-		// convert to grayscale and undistort both images
-		cv::Mat image_gray;
-		if(image.channels() == 3)
-		{
-			cv::Mat temp;
-			cv::remap(image, temp, undist_map1, undist_map2, cv::INTER_LINEAR);
-			cv::cvtColor(temp, image_gray, cv::COLOR_BGR2GRAY);
-			image = temp;
-		}
-		else
-		{
-			cv::remap(image, image_gray, undist_map1, undist_map2, cv::INTER_LINEAR);
-			cv::cvtColor(image_gray, image,  cv::COLOR_GRAY2BGR);
-		}
-		double t1 = tic(), t_undistort=t1-t0; t0=t1;
+        // convert to grayscale and undistort both images
+        cv::Mat image_gray;
+        if(image.channels() == 3)
+        {
+            cv::Mat temp;
+            cv::remap(image, temp, undist_map1, undist_map2, cv::INTER_LINEAR);
+            cv::cvtColor(temp, image_gray, cv::COLOR_BGR2GRAY);
+            image = temp;
+        }
+        else
+        {
+            cv::remap(image, image_gray, undist_map1, undist_map2, cv::INTER_LINEAR);
+            cv::cvtColor(image_gray, image,  cv::COLOR_GRAY2BGR);
+        }
+        double t1 = tic(), t_undistort=t1-t0; t0=t1;
 
-		// FIXME what is the use of this?
-		//Repeat processing on input set this many
-		int maxiters = conf.iters;
-		const int hamm_hist_max = 10;
+        // FIXME what is the use of this?
+        //Repeat processing on input set this many
+        int maxiters = conf.iters;
+        const int hamm_hist_max = 10;
 
-		std::vector<base::Vector2d> corners;
-		//main loop
-		for (int iter = 0; iter < maxiters; iter++)
-		{
-			if (maxiters > 1)
-				printf("iter %d / %d\n", iter + 1, maxiters);
-			int hamm_hist[hamm_hist_max];
-			memset(hamm_hist, 0, sizeof(hamm_hist));
+        std::vector<base::Vector2d> corners;
+        //main loop
+        for (int iter = 0; iter < maxiters; iter++)
+        {
+            if (maxiters > 1)
+                printf("iter %d / %d\n", iter + 1, maxiters);
+            int hamm_hist[hamm_hist_max];
+            memset(hamm_hist, 0, sizeof(hamm_hist));
 
             //convert cv::Mat to image_u8_t
-			//copying one row at once
-			image_u8_t *im = image_u8_create(image_gray.cols, image_gray.rows);
-			for(int i=0; i < image_gray.rows; ++i)
-			{
-				int jump = i*im->stride;
-				memcpy(im->buf+jump, image_gray.ptr(i), image_gray.step[0]*image_gray.elemSize());
-			}
-			double t1 = tic(), t_prepare=t1-t0;
+            //copying one row at once
+            image_u8_t *im = image_u8_create(image_gray.cols, image_gray.rows);
+            for(int i=0; i < image_gray.rows; ++i)
+            {
+                int jump = i*im->stride;
+                memcpy(im->buf+jump, image_gray.ptr(i), image_gray.step[0]*image_gray.elemSize());
+            }
+            double t1 = tic(), t_prepare=t1-t0;
 
-			//initialize time and detect markers
-			zarray_t *detections = apriltag_detector_detect(td, im);
-			double t2=tic();
-			double t_detect = t2-t1; t1=t2;
+            //initialize time and detect markers
+            zarray_t *detections = apriltag_detector_detect(td, im);
+            double t2=tic();
+            double t_detect = t2-t1; t1=t2;
 
             if (zarray_size(detections) != 0 && state() != MARKER_DETECTED)
             {
@@ -198,25 +200,25 @@ void Task::updateHook()
                 state(NO_MARKER_DETECTED);
             }
 
-			//build the rbs_vector and draw detected markers
-			std::vector<base::samples::RigidBodyState> rbs_vector;
-			for (int i = 0; i < zarray_size(detections); i++)
-			{
-				apriltag_detection_t *det;
-				zarray_get(detections, i, &det);
-				
-				double size;
-				
-				if( apriltag_id_to_size_.find( det->id) != apriltag_id_to_size_.end())
-				{
-				  size = apriltag_id_to_size_[ det->id];
-				}
-				else
-				{
-				  size = _marker_size.get();
-				}
+            //build the rbs_vector and draw detected markers
+            std::vector<base::samples::RigidBodyState> rbs_vector;
+            for (int i = 0; i < zarray_size(detections); i++)
+            {
+                apriltag_detection_t *det;
+                zarray_get(detections, i, &det);
 
-				//Compute pose
+                double size;
+
+                if( apriltag_id_to_size_.find( det->id) != apriltag_id_to_size_.end())
+                {
+                    size = apriltag_id_to_size_[ det->id];
+                }
+                else
+                {
+                    size = _marker_size.get();
+                }
+
+                //Compute pose
                 if(_pose_calculation.get())
                 {
                     base::samples::RigidBodyState rbs;
@@ -241,108 +243,110 @@ void Task::updateHook()
                         std::endl;
                 }        
 
-				for (int j=0; j < 4; ++j)
-				{
-					base::Vector2d aux;
-					aux[0] = det->p[j][0];
-					aux[1] = det->p[j][1];
-					corners.push_back(aux);
-				}
+                for (int j=0; j < 4; ++j)
+                {
+                    base::Vector2d aux;
+                    aux[0] = det->p[j][0];
+                    aux[1] = det->p[j][1];
+                    corners.push_back(aux);
+                }
 
 
-				if (!conf.quiet)
-					printf("detection %3d: id (%2dx%2d)-%-4d, hamming %d, goodness %8.3f, margin %8.3f\n",
-							i, det->family->d*det->family->d, det->family->h,
-							det->id, det->hamming, det->goodness, det->decision_margin);
+                if (!conf.quiet)
+                    printf("detection %3d: id (%2dx%2d)-%-4d, hamming %d, goodness %8.3f, margin %8.3f\n",
+                            i, det->family->d*det->family->d, det->family->h,
+                            det->id, det->hamming, det->goodness, det->decision_margin);
 
-				if (_draw_image.get())
-				{
-					draw(image,det->p, det->c, det->id, cv::Scalar(0,0,255), 2);
-					draw3dAxis(image, size, camera_k, cv::Mat());
-					draw3dCube(image, size, camera_k, cv::Mat());
-				}
+                if (_draw_image.get())
+                {
+                    draw(image,det->p, det->c, det->id, cv::Scalar(0,0,255), 2);
+                    draw3dAxis(image, size, camera_k, cv::Mat());
+                    draw3dCube(image, size, camera_k, cv::Mat());
+                }
 
-				hamm_hist[det->hamming]++;
+                hamm_hist[det->hamming]++;
 
-				apriltag_detection_destroy(det);
-			}
+                apriltag_detection_destroy(det);
+            }
 
-			if (!conf.quiet)
-			{
-				timeprofile_display(td->tp);
-				printf("nedges: %d, nsegments: %d, nquads: %d\n", td->nedges, td->nsegments, td->nquads);
-				printf("Hamming histogram: ");
-				for (int i = 0; i < hamm_hist_max; i++)
-					printf("%5d", hamm_hist[i]);
-				printf("%12.3f", timeprofile_total_utime(td->tp) / 1.0E3);
-				printf("\n");
-			}
+            if (!conf.quiet)
+            {
+                timeprofile_display(td->tp);
+                printf("nedges: %d, nsegments: %d, nquads: %d\n", td->nedges, td->nsegments, td->nquads);
+                printf("Hamming histogram: ");
+                for (int i = 0; i < hamm_hist_max; i++)
+                    printf("%5d", hamm_hist[i]);
+                printf("%12.3f", timeprofile_total_utime(td->tp) / 1.0E3);
+                printf("\n");
+            }
 
-			image_u8_destroy(im);
+            image_u8_destroy(im);
 
-			//write the the image in the output port
-			if (_draw_image.get())
-			{
-				base::samples::frame::Frame *pframe = out_frame_ptr.write_access();
-				frame_helper::FrameHelper::copyMatToFrame(image,*pframe);
-				pframe->time = base::Time::now();
-				out_frame_ptr.reset(pframe);
-				_output_image.write(out_frame_ptr);
-			}
+            //write the the image in the output port
+            if (_draw_image.get())
+            {
+                base::samples::frame::Frame *pframe = out_frame_ptr.write_access();
+                frame_helper::FrameHelper::copyMatToFrame(image,*pframe);
+                pframe->time = base::Time::now();
+                out_frame_ptr.reset(pframe);
+                _output_image.write(out_frame_ptr);
+            }
 
-			//write the corners in the output port
-			if (zarray_size(detections) != 0)
-			{
-				_detected_corners.write(corners);
-				corners.clear();
-			}
+            //write the corners in the output port
+            if (zarray_size(detections) != 0)
+            {
+                _detected_corners.write(corners);
+                corners.clear();
+            }
 
-			//write the markers in the output port
-			if (rbs_vector.size() != 0)
-			{
-				_marker_poses.write(rbs_vector);
-				_single_marker_pose.write( rbs_vector[0] );
-				rbs_vector.clear();
-			}
-			zarray_destroy(detections);
-		}
-	}
+            //write the markers in the output port
+            if (rbs_vector.size() != 0)
+            {
+                _marker_poses.write(rbs_vector);
+                _single_marker_pose.write( rbs_vector[0] );
+                rbs_vector.clear();
+            }
+            zarray_destroy(detections);
+        }
+    }
 }
 
 void Task::errorHook()
 {
     TaskBase::errorHook();
 }
+
 void Task::stopHook()
 {
     TaskBase::stopHook();
 }
+
 void Task::cleanupHook()
 {
-	// clean-up AprilTag detector:
-	apriltag_detector_destroy(td);
+    // clean-up AprilTag detector:
+    apriltag_detector_destroy(td);
 
-	switch (conf.family)
-	{
-	case TAG25H7:
-		tag25h7_destroy(tf);
-		break;
-	case TAG25H9:
-		tag25h9_destroy(tf);
-		break;
-	case TAG36H10:
-		tag36h10_destroy(tf);
-		break;
-	case TAG36H11:
-		tag36h11_destroy(tf);
-		break;
-	case TAG36ARTOOLKIT:
-		tag36artoolkit_destroy(tf);
-		break;
-	default:
-		throw std::runtime_error("The desired apriltag family code is not implemented");
-		break;
-	}
+    switch (conf.family)
+    {
+        case TAG25H7:
+            tag25h7_destroy(tf);
+            break;
+        case TAG25H9:
+            tag25h9_destroy(tf);
+            break;
+        case TAG36H10:
+            tag36h10_destroy(tf);
+            break;
+        case TAG36H11:
+            tag36h11_destroy(tf);
+            break;
+        case TAG36ARTOOLKIT:
+            tag36artoolkit_destroy(tf);
+            break;
+        default:
+            throw std::runtime_error("The desired apriltag family code is not implemented");
+            break;
+    }
 
     TaskBase::cleanupHook();
 }
@@ -404,7 +408,6 @@ void Task::getRbs(base::samples::RigidBodyState &rbs, float markerSizeMeters, do
 
 void Task::draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color, int lineWidth)const
 {
-
     cv::line( in,cv::Point(p[0][0], p[0][1]),cv::Point(p[1][0], p[1][1]),color,lineWidth,CV_AA);
     cv::line( in,cv::Point(p[1][0], p[1][1]),cv::Point(p[2][0], p[2][1]),color,lineWidth,CV_AA);
     cv::line( in,cv::Point(p[2][0], p[2][1]),cv::Point(p[3][0], p[3][1]),color,lineWidth,CV_AA);
@@ -415,18 +418,18 @@ void Task::draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color
     cv::rectangle( in,cv::Point(p[2][0], p[2][1]) - cv::Point(2,2),cv::Point(p[2][0], p[2][1])+cv::Point(2,2),cv::Scalar(255,0,0,255),lineWidth,CV_AA);
 
 
-        char cad[100];
-        sprintf(cad,"id=%d",id);
-        //determine the centroid
-        cv::Point cent(0,0);
-        for (int i=0;i<4;i++)
-        {
-            cent.x+=c[0];
-            cent.y+=c[1];
-        }
-        cent.x/=4.;
-        cent.y/=4.;
-        cv::putText(in,cad, cent,cv::FONT_HERSHEY_SIMPLEX, 1,  cv::Scalar(255-color[0],255-color[1],255-color[2],255),2);
+    char cad[100];
+    sprintf(cad,"id=%d",id);
+    //determine the centroid
+    cv::Point cent(0,0);
+    for (int i=0;i<4;i++)
+    {
+        cent.x+=c[0];
+        cent.y+=c[1];
+    }
+    cent.x/=4.;
+    cent.y/=4.;
+    cv::putText(in,cad, cent,cv::FONT_HERSHEY_SIMPLEX, 1,  cv::Scalar(255-color[0],255-color[1],255-color[2],255),2);
 
 }
 
@@ -435,31 +438,31 @@ void Task::draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Ma
     cv::Mat objectPoints (8,3,CV_32FC1);
     double halfSize=marker_size/2;
 
-      objectPoints.at<float>(0,0)=-halfSize;
-      objectPoints.at<float>(0,1)=-halfSize;
-      objectPoints.at<float>(0,2)=0;
-      objectPoints.at<float>(1,0)=-halfSize;
-      objectPoints.at<float>(1,1)=halfSize;
-      objectPoints.at<float>(1,2)=0;
-      objectPoints.at<float>(2,0)=halfSize;
-      objectPoints.at<float>(2,1)=halfSize;
-      objectPoints.at<float>(2,2)=0;
-      objectPoints.at<float>(3,0)=halfSize;
-      objectPoints.at<float>(3,1)=-halfSize;
-      objectPoints.at<float>(3,2)=0;
+    objectPoints.at<float>(0,0)=-halfSize;
+    objectPoints.at<float>(0,1)=-halfSize;
+    objectPoints.at<float>(0,2)=0;
+    objectPoints.at<float>(1,0)=-halfSize;
+    objectPoints.at<float>(1,1)=halfSize;
+    objectPoints.at<float>(1,2)=0;
+    objectPoints.at<float>(2,0)=halfSize;
+    objectPoints.at<float>(2,1)=halfSize;
+    objectPoints.at<float>(2,2)=0;
+    objectPoints.at<float>(3,0)=halfSize;
+    objectPoints.at<float>(3,1)=-halfSize;
+    objectPoints.at<float>(3,2)=0;
 
-      objectPoints.at<float>(4,0)=-halfSize;
-      objectPoints.at<float>(4,1)=-halfSize;
-      objectPoints.at<float>(4,2)=marker_size;
-      objectPoints.at<float>(5,0)=-halfSize;
-      objectPoints.at<float>(5,1)=halfSize;
-      objectPoints.at<float>(5,2)=marker_size;
-      objectPoints.at<float>(6,0)=halfSize;
-      objectPoints.at<float>(6,1)=halfSize;
-      objectPoints.at<float>(6,2)=marker_size;
-      objectPoints.at<float>(7,0)=halfSize;
-      objectPoints.at<float>(7,1)=-halfSize;
-      objectPoints.at<float>(7,2)=marker_size;
+    objectPoints.at<float>(4,0)=-halfSize;
+    objectPoints.at<float>(4,1)=-halfSize;
+    objectPoints.at<float>(4,2)=marker_size;
+    objectPoints.at<float>(5,0)=-halfSize;
+    objectPoints.at<float>(5,1)=halfSize;
+    objectPoints.at<float>(5,2)=marker_size;
+    objectPoints.at<float>(6,0)=halfSize;
+    objectPoints.at<float>(6,1)=halfSize;
+    objectPoints.at<float>(6,2)=marker_size;
+    objectPoints.at<float>(7,0)=halfSize;
+    objectPoints.at<float>(7,1)=-halfSize;
+    objectPoints.at<float>(7,2)=marker_size;
 
     std::vector<cv::Point2f> imagePoints;
     cv::projectPoints(objectPoints, rvec,tvec,  camMatrix ,distCoeff, imagePoints);
@@ -479,7 +482,7 @@ void Task::draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Ma
 
 void Task::draw3dAxis(cv::Mat &Image, float marker_size, cv::Mat camera_matrix, cv::Mat dist_matrix)
 {
-	float size=marker_size*2;
+    float size=marker_size*2;
     cv::Mat objectPoints (4,3,CV_32FC1);
     objectPoints.at<float>(0,0)=0;
     objectPoints.at<float>(0,1)=0;
@@ -519,7 +522,7 @@ std::string Task::getMarkerFrameName(int i)
     std::stringstream ss;
     ss << "apriltag_id_" << i << "_frame";
     std::string marker_frame_name = ss.str();
-    
+
     return marker_frame_name;
 }
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -189,11 +189,11 @@ void Task::updateHook()
 			double t2=tic();
 			double t_detect = t2-t1; t1=t2;
 
-            if (zarray_size(detections) != 0 & state() != MARKER_DETECTED)
+            if (zarray_size(detections) != 0 && state() != MARKER_DETECTED)
             {
                 state(MARKER_DETECTED);
             }
-            else if(zarray_size(detections) == 0 & state() != NO_MARKER_DETECTED)
+            else if(zarray_size(detections) == 0 && state() != NO_MARKER_DETECTED)
             {
                 state(NO_MARKER_DETECTED);
             }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -43,32 +43,32 @@ namespace apriltags {
      */
     class Task : public TaskBase
     {
-	friend class TaskBase;
-    protected:
+        friend class TaskBase;
+        protected:
 
-    apriltags::ApriltagsConfig conf;
-    apriltag_family_t *tf;
-    apriltag_detector_t *td;
+        apriltags::ApriltagsConfig conf;
+        apriltag_family_t *tf;
+        apriltag_detector_t *td;
 
-    cv::Mat camera_k, camera_dist;
-    cv::Mat rvec, tvec;
-    // Maps for faster undistortion:
-    cv::Mat undist_map1, undist_map2;
-    double scaling;
+        cv::Mat camera_k, camera_dist;
+        cv::Mat rvec, tvec;
+        // Maps for faster undistortion:
+        cv::Mat undist_map1, undist_map2;
+        double scaling;
 
 
-    RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> out_frame_ptr;
+        RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> out_frame_ptr;
 
-    std::map<int, double> apriltag_id_to_size_; //Mapping from ID to size
-    
-    void getRbs(base::samples::RigidBodyState &rbs, float markerSizeMeters, double points[][2], cv::Mat  camMatrix,cv::Mat distCoeff)throw(cv::Exception);
-    void draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color, int lineWidth)const;
-    void draw3dAxis(cv::Mat &Image, float marker_size, cv::Mat camera_matrix, cv::Mat dist_matrix);
-    void draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Mat distCoeff);
-    double tic();
-    std::string getMarkerFrameName(int i);
+        std::map<int, double> apriltag_id_to_size_; //Mapping from ID to size
 
-    public:
+        void getRbs(base::samples::RigidBodyState &rbs, float markerSizeMeters, double points[][2], cv::Mat  camMatrix,cv::Mat distCoeff)throw(cv::Exception);
+        void draw(cv::Mat &in, double p[][2], double c[], int id, cv::Scalar color, int lineWidth)const;
+        void draw3dAxis(cv::Mat &Image, float marker_size, cv::Mat camera_matrix, cv::Mat dist_matrix);
+        void draw3dCube(cv::Mat &Image,float marker_size,cv::Mat  camMatrix,cv::Mat distCoeff);
+        double tic();
+        std::string getMarkerFrameName(int i);
+
+        public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
@@ -84,7 +84,7 @@ namespace apriltags {
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~Task();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -95,8 +95,8 @@ namespace apriltags {
          * in the task context definition with (for example):
          \verbatim
          task_context "TaskName" do
-           needs_configuration
-           ...
+         needs_configuration
+         ...
          end
          \endverbatim
          */


### PR DESCRIPTION
It perform the following changes:
- Adds a property that can set either the markers or the camera as reference frame;
- Adds a property to no compute the pose, this is useful to save some processing when, for instance, only the corners are needed;
-  Renames the camera frame name property to match the transformer convention
