### PR TITLE
Check if the marker size is valid

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -218,8 +218,13 @@ void Task::updateHook()
                     size = _marker_size.get();
                 }
 
+                bool pose_calculation = _pose_calculation.get();
+
+                if (size <=0)
+                    pose_calculation = false;
+
                 //Compute pose
-                if(_pose_calculation.get())
+                if(pose_calculation)
                 {
                     base::samples::RigidBodyState rbs;
                     getRbs(rbs, size, det->p, camera_k, cv::Mat());
@@ -260,8 +265,11 @@ void Task::updateHook()
                 if (_draw_image.get())
                 {
                     draw(image,det->p, det->c, det->id, cv::Scalar(0,0,255), 2);
-                    draw3dAxis(image, size, camera_k, cv::Mat());
-                    draw3dCube(image, size, camera_k, cv::Mat());
+                    if(pose_calculation)
+                    {
+                        draw3dAxis(image, size, camera_k, cv::Mat());
+                        draw3dCube(image, size, camera_k, cv::Mat());
+                    }
                 }
 
                 hamm_hist[det->hamming]++;


### PR DESCRIPTION
Set the pose_calculation property to false if the marker size is less than zero.
This avoids breaks the system when:
Have id-to-size list ->  Detect a non-listed id -> The marker_size property is set to -1 (default value).

For that case, the behavior now is detect the marker (draw its borders), but do not compute its pose.
