### PR TITLE
Provides the feature points of a marker in a time-stamped type

### DIFF
--- a/apriltags.orogen
+++ b/apriltags.orogen
@@ -63,7 +63,7 @@ task_context "Task" do
         .doc 'It contains the calculated marker poses in respect to camera frame of all visible markers'
     output_port("single_marker_pose", "base::samples::RigidBodyState")
 	.doc 'It contains a single calculated marker pose in respect to camera of a deteted visable marker'
-    output_port("detected_corners", "std/vector<apriltags/VisualFeaturePoint>")
+    output_port("detected_corners", "apriltags/VisualFeaturePoints")
      	.doc 'Writes the camera calibration to be acessible to other components' 	
      	
     runtime_states :MARKER_DETECTED, :NO_MARKER_DETECTED

--- a/apriltagsTypes.hpp
+++ b/apriltagsTypes.hpp
@@ -57,8 +57,13 @@ namespace apriltags {
        std::string identifier;
        std::vector<base::Vector2d> points;
    };
-}
 
+   struct VisualFeaturePoints
+   {
+       base::Time time;
+       std::vector<VisualFeaturePoint> feature_points;
+   };
+}
 
 
 #endif

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -163,7 +163,7 @@ void Task::updateHook()
         int maxiters = conf.iters;
         const int hamm_hist_max = 10;
 
-        std::vector<apriltags::VisualFeaturePoint> corners;
+        apriltags::VisualFeaturePoints corners;
         //main loop
         for (int iter = 0; iter < maxiters; iter++)
         {
@@ -250,7 +250,8 @@ void Task::updateHook()
                     base::Vector2d aux(det->p[j][0], det->p[j][1]);
                     temp.points.push_back(aux / scaling);
                 }
-                corners.push_back(temp);
+                corners.feature_points.push_back(temp);
+                corners.time = current_frame_ptr->time;
 
                 if (!conf.quiet)
                     printf("detection %3d: id (%2dx%2d)-%-4d, hamming %d, goodness %8.3f, margin %8.3f\n",
@@ -314,10 +315,10 @@ void Task::updateHook()
             }
 
             //write the corners in the output port
-            if (corners.size() != 0)
+            if (corners.feature_points.size() != 0)
             {
                 _detected_corners.write(corners);
-                corners.clear();
+                corners.feature_points.clear();
             }
 
             //write the markers in the output port


### PR DESCRIPTION
The alternative, defining the `determineTimestamp` method for a container type, isn't a good option in my opinion.